### PR TITLE
38 fix docs

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -4,7 +4,7 @@
     <a href="https://dribia.github.io/dbt2pdf">
         <img
             src="../img/logo_dribia_blau_cropped.png"
-            alt="dbt2PDF"
+            alt="dbt2pdf"
             style="display: block; margin-left: auto; margin-right: auto; width: 40%;"
         >
     </a>
@@ -15,7 +15,7 @@
 </p>
 
 ## Mantainers
-dbt2PDF is maintained by:
+dbt2pdf is maintained by:
 
 * Dribia Code - <code@dribia.com>
 
@@ -27,7 +27,7 @@ Please note which version of the library are you using whenever reporting a bug.
 python -c "import dbt2pdf; print(dbt2pdf.__version__)"
 ```
 
-It would be very useful too to know which OS and Python version are your running dbt2PDF from.
+It would be very useful too to know which OS and Python version are your running dbt2pdf from.
 
 ## Contribute
 In order to contribute, the first step is to clone yourself the code:

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,4 +73,4 @@ dbt2pdf generate \
   --add-author john@example.com \
   --add-author doe@example.com \
   output.pdf
-``
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@
 
 ---
 
-dbt2PDF provides a command-line interface (CLI) to convert dbt models to PDF files.
+dbt2pdf provides a command-line interface (CLI) to convert dbt models to PDF files.
 
 ## Key features
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,7 @@ Installation is as simple as:
 ```shell
 pip install dbt2pdf
 ```
-dbt2PDF heavily depends on a Python library,
+dbt2pdf heavily depends on a Python library,
 that will be installed as dependencies:
 
 * [**fpdf2**](https://py-pdf.github.io/fpdf2/) is _a library for simple & fast PDF document generation in Python._

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,3 +79,9 @@ dbt2pdf generate \
  --add-logo "path/to/logo1.png"
  --add-logo "path/to/logo2.png"
 ```
+
+!!! Warning
+    There is a maximum of two logos that can be included.
+    The first one in the command line will be bigger and displayed on top of
+    the title page, whereas the second one will be smaller and displayed under
+    the title on the title page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: dbt2PDF
+site_name: dbt2pdf
 site_description: Python package to convert dbt models to PDF files.
 strict: true
 
@@ -12,7 +12,7 @@ repo_name: dribia/dbt2pdf
 repo_url: https://github.com/dribia/dbt2pdf
 edit_uri: ''
 nav:
-  - Welcome to dbt2PDF: index.md
+  - Welcome to dbt2pdf: index.md
   - Installation: install.md
   - Usage: usage.md
   - Contribute: contribute.md


### PR DESCRIPTION
@airibarne Al final lo del logo blau sembla que aquí està OK. Hi ha opcions per dark/light theme (que no sé ben bé on es triaria):
```
<p align="center">
    <a href="https://dribia.github.io/dbt2pdf">
        <picture style="display: block; margin-left: auto; margin-right: auto; width: 40%;">
            <source
                media="(prefers-color-scheme: dark)"
                srcset="https://dribia.github.io/dbt2pdf/img/logo_dribia_blanc_cropped.png"
            >
            <source
                media="(prefers-color-scheme: light)"
                srcset="https://dribia.github.io/dbt2pdf/img/logo_dribia_blau_cropped.png"
            >
            <img
                alt="dbt2pdf"
                src="https://dribia.github.io/dbt2pdf/img/logo_dribia_blau_cropped.png"
            >
        </picture>
    </a>
</p>
```

He fet la resta de canvis que posaves i he afegit una mica d'info extra sobre logos (que només se n'hi poden posar dos i com queden).